### PR TITLE
Adding conv2d_backward_data to parser

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpenOps/MIOpenOps.td
+++ b/mlir/include/mlir/Dialect/MIOpenOps/MIOpenOps.td
@@ -43,9 +43,20 @@ def MIOpen_Conv2DOp :
     Arguments<(ins MemRefRankOf<[F32], [4]>:$filter,
                    MemRefRankOf<[F32], [4]>:$input,
                    MemRefRankOf<[F32], [4]>:$output)> {
-  let summary = "2D convolution";
+  let summary = "2D convolution forward";
   let description = [{
-    The `miopen.conv2d` op computes 2D convolution.
+    The `miopen.conv2d` op computes 2D convolution forward.
+  }];
+}
+
+def MIOpen_Conv2DBwdDataOp :
+    MIOpen_Op<"conv2d_bwd_data">,
+    Arguments<(ins MemRefRankOf<[F32], [4]>:$filter,
+                   MemRefRankOf<[F32], [4]>:$input,
+                   MemRefRankOf<[F32], [4]>:$output)> {
+  let summary = "2D convolution backward data";
+  let description = [{
+    The `miopen.conv2d` op computes 2D convolution backward data.
   }];
 }
 

--- a/mlir/lib/Dialect/MIOpenOps/Driver/mlir-miopen-driver.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/Driver/mlir-miopen-driver.cpp
@@ -29,8 +29,6 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <iostream>
-
 using namespace llvm;
 using namespace mlir;
 
@@ -39,8 +37,9 @@ static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
                                            cl::init("-"));
 
 static cl::opt<std::string>
-    convFlavor("conv_flavor", cl::desc("Convolution Flavor"),
-               cl::value_desc("convolution flavor string"), cl::init("conv2d"));
+    operation("operation",
+              cl::desc("Convolution operation, eg: conv2d, conv2d_bwd_data..."),
+              cl::value_desc("convolution flavor string"), cl::init("conv2d"));
 
 static cl::opt<std::string> filterLayout("fil_layout", cl::desc("Filter layout"),
                                               cl::value_desc("layout string"),
@@ -134,8 +133,6 @@ static cl::opt<bool> populateDefaultValues("p", cl::desc("To populate default va
                                                 cl::value_desc("To populate default values"),
                                                 cl::init(false));
 
-void constructConvModule() {}
-
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
@@ -213,7 +210,7 @@ int main(int argc, char **argv) {
   auto funcType = builder.getFunctionType({filterArgType, inputArgType, outputArgType}, {});
   auto func =
       FuncOp::create(builder.getUnknownLoc(),
-                     "miopen_" + convFlavor.getValue() + "_" + filterLayout +
+                     "miopen_" + operation.getValue() + "_" + filterLayout +
                          "_" + inputLayout + "_" + outputLayout,
                      funcType);
   module.push_back(func);
@@ -231,83 +228,49 @@ int main(int argc, char **argv) {
     outputLayoutSpec.push_back(builder.getStringAttr((StringRef(&outputLayout.getValue()[i], 1) + "o").str()));
   }
 
-  if (convFlavor.getValue().compare("conv2d") == 0) {
+  std::vector<NamedAttribute> attributes{
+      builder.getNamedAttr(
+          "filter_layout",
+          builder.getArrayAttr(ArrayRef<Attribute>(filterLayoutSpec.begin(),
+                                                   filterLayoutSpec.end()))),
+      builder.getNamedAttr(
+          "input_layout", builder.getArrayAttr(ArrayRef<Attribute>(
+                              inputLayoutSpec.begin(), inputLayoutSpec.end()))),
+      builder.getNamedAttr(
+          "output_layout",
+          builder.getArrayAttr(ArrayRef<Attribute>(outputLayoutSpec.begin(),
+                                                   outputLayoutSpec.end()))),
+
+      builder.getNamedAttr(
+          "dilations", builder.getArrayAttr({
+                           builder.getI32IntegerAttr(dilationHeight.getValue()),
+                           builder.getI32IntegerAttr(dilationWidth.getValue()),
+                       })),
+      builder.getNamedAttr(
+          "strides", builder.getArrayAttr({
+                         builder.getI32IntegerAttr(strideHeight.getValue()),
+                         builder.getI32IntegerAttr(strideWidth.getValue()),
+                     })),
+      builder.getNamedAttr(
+          "padding", builder.getArrayAttr({
+                         builder.getI32IntegerAttr(paddingHeight.getValue()),
+                         builder.getI32IntegerAttr(paddingWidth.getValue()),
+                     })),
+  };
+
+  if (operation.getValue().compare("conv2d") == 0) {
     auto convOp = builder.create<miopen::Conv2DOp>(
         builder.getUnknownLoc(), ArrayRef<Type>({}),
         ValueRange{block->getArgument(0), block->getArgument(1),
                    block->getArgument(2)},
-        ArrayRef<NamedAttribute>{
-            builder.getNamedAttr(
-                "filter_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    filterLayoutSpec.begin(), filterLayoutSpec.end()))),
-            builder.getNamedAttr(
-                "input_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    inputLayoutSpec.begin(), inputLayoutSpec.end()))),
-            builder.getNamedAttr(
-                "output_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    outputLayoutSpec.begin(), outputLayoutSpec.end()))),
-
-            builder.getNamedAttr(
-                "dilations",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(dilationHeight.getValue()),
-                    builder.getI32IntegerAttr(dilationWidth.getValue()),
-                })),
-            builder.getNamedAttr(
-                "strides",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(strideHeight.getValue()),
-                    builder.getI32IntegerAttr(strideWidth.getValue()),
-                })),
-            builder.getNamedAttr(
-                "padding",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(paddingHeight.getValue()),
-                    builder.getI32IntegerAttr(paddingWidth.getValue()),
-                })),
-        });
+        attributes);
     block->push_back(convOp);
-  } else if (convFlavor.getValue().compare("conv2d_bwd_data") == 0) {
+  } else if (operation.getValue().compare("conv2d_bwd_data") == 0) {
     auto convOp = builder.create<miopen::Conv2DBwdDataOp>(
         builder.getUnknownLoc(), ArrayRef<Type>({}),
         ValueRange{block->getArgument(0), block->getArgument(1),
                    block->getArgument(2)},
-        ArrayRef<NamedAttribute>{
-            builder.getNamedAttr(
-                "filter_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    filterLayoutSpec.begin(), filterLayoutSpec.end()))),
-            builder.getNamedAttr(
-                "input_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    inputLayoutSpec.begin(), inputLayoutSpec.end()))),
-            builder.getNamedAttr(
-                "output_layout",
-                builder.getArrayAttr(ArrayRef<Attribute>(
-                    outputLayoutSpec.begin(), outputLayoutSpec.end()))),
-
-            builder.getNamedAttr(
-                "dilations",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(dilationHeight.getValue()),
-                    builder.getI32IntegerAttr(dilationWidth.getValue()),
-                })),
-            builder.getNamedAttr(
-                "strides",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(strideHeight.getValue()),
-                    builder.getI32IntegerAttr(strideWidth.getValue()),
-                })),
-            builder.getNamedAttr(
-                "padding",
-                builder.getArrayAttr({
-                    builder.getI32IntegerAttr(paddingHeight.getValue()),
-                    builder.getI32IntegerAttr(paddingWidth.getValue()),
-                })),
-        });
+        attributes);
     block->push_back(convOp);
   }
 

--- a/mlir/lib/Dialect/MIOpenOps/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/LowerMIOpenOps.cpp
@@ -589,19 +589,20 @@ struct Conv2DOpRewritePattern : public OpRewritePattern<miopen::Conv2DOp> {
     auto rightPadW = wiPadded > (leftPadW + wi) ? wiPadded - (leftPadW + wi) : 0;
  
     // Set attributes for gridwise_gemm op.
-    llvm::SmallVector<NamedAttribute, 8> gridwiseGemmAttrs {
-      b.getNamedAttr("filter_layout", filterLayoutAttr),
-      b.getNamedAttr("filter_dimension", b.getI64ArrayAttr(filterShape)),
-      b.getNamedAttr("input_layout", inputLayoutAttr),
-      b.getNamedAttr("input_dimension", b.getI64ArrayAttr(inputShape)),
-      b.getNamedAttr("output_layout", outputLayoutAttr),
-      b.getNamedAttr("output_dimension", b.getI64ArrayAttr(outputShape)),
-      b.getNamedAttr("dilations",  dilationsAttr),
-      b.getNamedAttr("strides", stridesAttr),
-      b.getNamedAttr("padding", b.getArrayAttr({
-        paddingAttr,
-        b.getI32ArrayAttr({rightPadH, rightPadW})
-      })),
+    llvm::SmallVector<NamedAttribute, 8> gridwiseGemmAttrs{
+        b.getNamedAttr("kernel_algorithm", b.getStringAttr("v4r4")),
+        b.getNamedAttr("filter_layout", filterLayoutAttr),
+        b.getNamedAttr("filter_dimension", b.getI64ArrayAttr(filterShape)),
+        b.getNamedAttr("input_layout", inputLayoutAttr),
+        b.getNamedAttr("input_dimension", b.getI64ArrayAttr(inputShape)),
+        b.getNamedAttr("output_layout", outputLayoutAttr),
+        b.getNamedAttr("output_dimension", b.getI64ArrayAttr(outputShape)),
+        b.getNamedAttr("dilations", dilationsAttr),
+        b.getNamedAttr("strides", stridesAttr),
+        b.getNamedAttr(
+            "padding",
+            b.getArrayAttr(
+                {paddingAttr, b.getI32ArrayAttr({rightPadH, rightPadW})})),
     };
     // Emit miopen.gridwise_gemm op.
     b.create<miopen::GridwiseGemmOp>(op.getLoc(), ArrayRef<Type>{}, ValueRange{gemmA, gemmB, gemmC}, gridwiseGemmAttrs);

--- a/mlir/lib/Dialect/MIOpenOps/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/LowerMIOpenOps.cpp
@@ -590,7 +590,6 @@ struct Conv2DOpRewritePattern : public OpRewritePattern<miopen::Conv2DOp> {
  
     // Set attributes for gridwise_gemm op.
     llvm::SmallVector<NamedAttribute, 8> gridwiseGemmAttrs{
-        b.getNamedAttr("kernel_algorithm", b.getStringAttr("v4r4")),
         b.getNamedAttr("filter_layout", filterLayoutAttr),
         b.getNamedAttr("filter_dimension", b.getI64ArrayAttr(filterShape)),
         b.getNamedAttr("input_layout", inputLayoutAttr),

--- a/mlir/lib/Dialect/MIOpenOps/MIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/MIOpenOps.cpp
@@ -67,6 +67,29 @@ static LogicalResult verify(Conv2DOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// Conv2DBwdDataOp
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseConv2DBwdDataOp(OpAsmParser &parser,
+                                        OperationState &result) {
+  SmallVector<OpAsmParser::OperandType, 3> ops;
+  SmallVector<Type, 3> types;
+  return failure(
+      parser.parseOperandList(ops, OpAsmParser::Delimiter::Paren) ||
+      parser.parseOptionalAttrDict(result.attributes) ||
+      parser.parseColonTypeList(types) ||
+      parser.resolveOperands(ops, types, parser.getNameLoc(), result.operands));
+}
+
+static void print(OpAsmPrinter &p, Conv2DBwdDataOp op) {
+  p << op.getOperationName() << "(" << op.getOperands() << ")";
+  p.printOptionalAttrDict(op.getAttrs());
+  p << " : " << op.getOperandTypes();
+}
+
+static LogicalResult verify(Conv2DBwdDataOp op) { return success(); }
+
+//===----------------------------------------------------------------------===//
 // TransformOp
 //===----------------------------------------------------------------------===//
 

--- a/mlir/test/Dialect/MIOpen/ops.mlir
+++ b/mlir/test/Dialect/MIOpen/ops.mlir
@@ -14,7 +14,22 @@ func @miopen_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>,
   return
 }
 // CHECK-LABEL: func @miopen_conv2d
-//  CHECK-NEXT: miopen.conv2d
+// CHECK-NEXT: miopen.conv2d
+
+func @miopen_conv2d_bwd_data(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
+  miopen.conv2d_bwd_data(%filter, %input, %output) {
+    filter_layout = ["k", "c", "y", "x"],
+    input_layout = ["n", "c", "hi", "wi"],
+    output_layout = ["n", "k", "ho", "wo"],
+    dilations = [1, 1],
+    strides = [1, 1],
+    padding = [0, 0]
+  } : memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
+  return
+}
+// CHECK-LABEL: func @miopen_conv2d_bwd_data
+// CHECK-NEXT: miopen.conv2d_bwd_data
+
 
 // test 1-1 dimension mappings.
 func @miopen_transform_1_to_1(%memref: memref<?x?x?x?xf32>) {


### PR DESCRIPTION
* Updated table-gen to generate the new conv2d_backward_data high level
  operation
* Updated mlir-miopen-driver to branch based on conv_flavor
* Added kernel_algorithm field to existing lowering step
* Added conv2d_backward_data test case

--------------------
Tests:

- $ cd build && cmake --build . --target mlir-miopen-driver && bin/mlir-miopen-driver --conv_flavor conv2d_bwd_data
   - Output:
``` mlir
$ module {
  func @miopen_conv2d_bwd_data_kcyx_nchw_nkhw(%arg0: memref<?x?x?x?xf32>, %arg1: memref<?x?x?x?xf32>, %arg2: memref<?x?x?x?xf32>) {
    miopen.conv2d_bwd_data(%arg0, %arg1, %arg2) {dilations = [1 : i32, 1 : i32], filter_layout = ["k", "c", "y", "x"], input_layout = ["ni", "ci", "hi", "wi"], output_layout = ["no", "ko", "ho", "wo"], padding = [0 : i32, 0 : i32], strides = [1 : i32, 1 : i32]} :        memref<?x?x?x?xf32>, memref<?x?x?x?xf32>, memref<?x?x?x?xf32>
    return
  }   
```
-   $ cd build &&  cmake --build . --target check-mlir
    - Output: All passing
-   $ cd build && cmake --build . --target mlir-opt  && bin/mlir-miopen-driver -p --conv_flavor conv2d_bwd_data | /root/llvm-project/build/bin/mlir-opt
    - Output: Round trip fine

