### PR TITLE
Fixing translation pass according to bwd  data bringup

### DIFF
--- a/mlir/test/Dialect/MIOpen/translate_bwd_data_kcyx_nchw_nkhw.mlir
+++ b/mlir/test/Dialect/MIOpen/translate_bwd_data_kcyx_nchw_nkhw.mlir
@@ -145,8 +145,11 @@ func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?
     // tuning parameters
     kernel_algorithm = "backward_data_v1r1",
     filter_layout = ["k", "c", "y", "x"],
+    filter_dimension = [4, 16, 4, 2],
     input_layout = ["ni", "ci", "hi", "wi"],
-    output_layout = ["no", "ko", "ho", "wo"]
+    input_dimension = [32, 16, 32, 32],
+    output_layout = ["no", "ko", "ho", "wo"],
+    output_dimension = [32, 4, 29, 31]
   } : memref<?x?xf32>,
       memref<?x?xf32>,
       memref<?x?xf32>

--- a/mlir/test/Dialect/MIOpen/translate_forward_kcyx_nchw_nkhw.mlir
+++ b/mlir/test/Dialect/MIOpen/translate_forward_kcyx_nchw_nkhw.mlir
@@ -145,8 +145,11 @@ func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?
     // tuning parameters
     kernel_algorithm = "v4r4",
     filter_layout = ["k", "c", "y", "x"],
+    filter_dimension = [4, 16, 4, 2],
     input_layout = ["ni", "ci", "hi", "wi"],
-    output_layout = ["no", "ko", "ho", "wo"]
+    input_dimension = [32, 16, 32, 32],
+    output_layout = ["no", "ko", "ho", "wo"],
+    output_dimension = [32, 4, 29, 31]
   } : memref<?x?xf32>,
       memref<?x?xf32>,
       memref<?x?xf32>


### PR DESCRIPTION
* Fix SRC_DATA_PER_READ_GEMM tuning parameter naming
* Updating include filename to match with forward naming convention
* Fix need_atomic kHeaderEpilogue string
* Disable CK_USE_AMD_BUFFER_ATOMIC_ADD turning parameter in gfx906
* Fix check-mlir target