### PR TITLE
Rework tuning parameter generation

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpenOps/MIOpenCPP.h
+++ b/mlir/include/mlir/Dialect/MIOpenOps/MIOpenCPP.h
@@ -91,16 +91,10 @@ T integer_least_multiple(T x, T y)
 }
 
 struct ConvolutionContext {
-    int64_t k, c, y, x;
-    int64_t n, hi, wi;
-    int64_t ho, wo;
-    int64_t strideH, strideW;
-    int64_t dilationH, dilationW;
-    int64_t paddingHL, paddingHR, paddingWL, paddingWR;
-
-    size_t dimKF, dimCF, dimYF, dimXF;
-    size_t dimNO, dimKO, dimHO, dimWO;
-    size_t dimNI, dimCI, dimHI, dimWI;
+  llvm::StringMap<std::pair<size_t, int64_t>> dimIndexVal;
+  llvm::SmallVector<int64_t, 0> strideVal;
+  llvm::SmallVector<int64_t, 0> dilationVal;
+  llvm::SmallVector<int64_t, 0> paddingVal;
 };
 
 class TunableParametersBase {
@@ -117,10 +111,7 @@ public:
     }
   }
 
-  void initWithContext(ConvolutionContext &ctx) {
-    this->ctx = ctx;
-    init();
-  }
+  void setContext(ConvolutionContext &ctx) { this->ctx = ctx; }
 
   virtual void customInit() = 0;
 

--- a/mlir/include/mlir/Dialect/MIOpenOps/MIOpenCPP.h
+++ b/mlir/include/mlir/Dialect/MIOpenOps/MIOpenCPP.h
@@ -97,6 +97,14 @@ struct ConvolutionContext {
   llvm::SmallVector<int64_t, 0> paddingVal;
 };
 
+struct TunableParams {
+  int64_t gemmMPerBlock;
+  int64_t gemmNPerBlock;
+  int64_t gemmKPerBlock;
+  int64_t gemmMPerWave;
+  int64_t gemmNPerWave;
+};
+
 class TunableParametersBase {
 public:
   TunableParametersBase(llvm::StringRef &&yamlFileName) : params(), configFileName(yamlFileName), ctx() {}

--- a/mlir/lib/Dialect/MIOpenOps/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -978,10 +978,10 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeader(ModuleOp m)
           op.getAttrOfType<ArrayAttr>("filter_dimension");
       populateDimVal(filterLayoutAttr, filterDimensionAttr, dimIndexVal);
 
-      PopulateParamsBase::obtainInput1VecGemmKVectorizable(
-          opType, dimIndexVal, input1GemmKVectorizable);
-      PopulateParamsBase::obtainInput2VecGemmKVectorizable(
-          opType, dimIndexVal, input2GemmKVectorizable);
+      PopulateParamsBase::obtainGemmADimKVectorizable(opType, dimIndexVal,
+                                                      input1GemmKVectorizable);
+      PopulateParamsBase::obtainGemmBDimKVectorizable(opType, dimIndexVal,
+                                                      input2GemmKVectorizable);
     });
 
     EmitHeaderEpilogue(output, gridwiseGemmArguments, input1GemmKVectorizable,
@@ -1135,7 +1135,7 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlags(ModuleOp m)
         // gemmM vectorizable. However, there is no parameters for vectorizing
         // gemmM dimension for matrix C. Do nothing here.
       } else {
-        PopulateParams::obtainOutputVecLen(opType, dimIndexVal, outputVecLen);
+        PopulateParams::obtainGemmCVecLen(opType, dimIndexVal, outputVecLen);
       }
 
       if ((outputVecLen > 0) && (outputVecLen % 4 == 0)) {

--- a/mlir/lib/Dialect/MIOpenOps/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/mlir/lib/Dialect/MIOpenOps/CppOutput/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -55,21 +55,18 @@ private:
            (params.gemmMPerWave * params.gemmNPerWave);
   }
 
-  // TBD: review logic here as they may be tied to NCHW layout.
   LogicalResult calculateGemmABlockCopyPerformanceParameters(
       InitParamsXDL *param, ConvolutionContext &ctx, DerivedParams &derived) {
     int64_t blockSize = obtainBlockSize(*param, waveSize);
     return calculateInputDerivedParams(param, blockSize, ctx, true, derived);
   }
 
-  // TBD: review logic here as they may be tied to NCHW layout.
   LogicalResult calculateGemmBBlockCopyPerformanceParameters(
       InitParamsXDL *param, ConvolutionContext &ctx, DerivedParams &derived) {
     int64_t blockSize = obtainBlockSize(*param, waveSize);
     return calculateInputDerivedParams(param, blockSize, ctx, false, derived);
   }
 
-  // TBD: review logic here as they may be tied to NCHW layout.
   LogicalResult calculateLdsNumberOfByte(InitParamsXDL *param,
                                          ConvolutionContext &ctx,
                                          size_t &ldsSize) {
@@ -1104,7 +1101,6 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlagsXDLOPS(Modul
       // TBD: be able to set data type.
       output << " -DMIOPEN_USE_FP32=1 -DMIOPEN_USE_FP16=0 -DMIOPEN_USE_BFP16=0";
 
-      // TBD: be able to set convolution direction.
       output << " -DCK_PARAM_PROBLEM_CONV_DIRECTION_FORWARD=1";
       output << " -DCK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_DATA=0";
       output << " -DCK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_WEIGHT=0";


### PR DESCRIPTION
Abstracted majority of tuning parameter generation to a class hierachy:

- Base class: `PopulateParamsBase`; 
  - Reworked the data structures to hold tuning parameters
  - It holds all shared functionalities to calculate vectorization tuning parameters
  - Adopted the XDL population logic between a set of tunable parameters to start with to non-XDL population
- Child class: `PopulateParams and PopulateParamsXDL`
  - Entry point simplified to one `calculateInputDerivedParams` function
- TunableParameters class:
  - Removed the tuning parameter generation
  - Make its sole responsibility to handle generated parameters

Possible future work (desirably done when we have bww):

- Migrate the tuning parameter class to a separate compilation unit

@whchung @asroy @zjing14