### PR TITLE
Adding lower-affine and convert-loop-to-std to lowering step3

### DIFF
--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -23,6 +23,8 @@
 #include "PassDetail.h"
 #include "mlir/Dialect/MIOpen/LowerMIOpenOps.h"
 
+#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
+#include "mlir/Conversion/LoopToStandard/ConvertLoopToStandard.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/MIOpen/Passes.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
@@ -81,6 +83,8 @@ void LowerMIOpenOpsStep3Pass::runOnOperation() {
   patterns.insert<BlockwiseGemmRewritePattern>(&getContext());
   patterns.insert<BlockwiseCopyRewritePattern>(&getContext());
   patterns.insert<ThreadwiseGemmRewritePattern>(&getContext());
+  populateAffineToStdConversionPatterns(patterns, &getContext());
+  populateLoopToStdConversionPatterns(patterns, &getContext());
   applyPatternsAndFoldGreedily(getOperation(), patterns);
 }
 


### PR DESCRIPTION
Added `--lower-affine` and `--convert-loop-to-std` to `-miopen-lowering-step3`. The below lowering pass can work.

> ./bin/mlir-miopen-driver -p | ./bin/mlir-opt -miopen-lowering -miopen-affine-transform -miopen-affix-params -miopen-lowering-step2  -miopen-lowering-step3 -convert-miopen-to-gpu -convert-gpu-to-rocdl 