### PR TITLE
Enable mlir-miopen-driver blockSize override

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/Passes.h
+++ b/mlir/include/mlir/Dialect/MIOpen/Passes.h
@@ -46,6 +46,7 @@ std::unique_ptr<Pass> createAffineTransformPass();
 
 /// Create a pass to affix tuning parameters to gridwise gemm ops.
 std::unique_ptr<Pass> createAffixTuningParametersPass(
+    int64_t blockSizeOverride = 0,
     LaunchDimensionCallback launchDimCallback = nullptr);
 
 } // namespace miopen

--- a/mlir/include/mlir/Dialect/MIOpen/gridwise_gemm_params.h
+++ b/mlir/include/mlir/Dialect/MIOpen/gridwise_gemm_params.h
@@ -565,13 +565,17 @@ struct InitParamsNonXDL : InitParams {
 
 class PopulateParams : public PopulateParamsBase {
 private:
+  // clang-format off
   llvm::SmallVector<InitParamsNonXDL, 4> initParameters = {
       // M/block N/block K/block M/thread N/thread blockSize
       {128, 128, 8, 4, 4, 256},
       {128, 64, 8, 4, 4, 128},
       {64, 128, 4, 4, 4, 128},
+      {64, 64, 16, 4, 4, 64},
+      {32, 64, 16, 2, 4, 64},
       {32, 32, 4, 2, 2, 64},
   };
+  // clang-format on
 
   LogicalResult
   calculateGemmABlockCopyPerformanceParameters(InitParamsNonXDL *param,
@@ -624,6 +628,12 @@ public:
     obtainGemmSize(ctx, gemmSize);
 
     for (auto &params : initParameters) {
+      // We have an override on the blockSize, only loop through the
+      // initParameters with the same blockSize
+      if ((validParams.blockSize != 0) &&
+          (validParams.blockSize != params.blockSize)) {
+        continue;
+      }
 
       res = isValidGemm(&params, gemmSize);
       if (failed(res)) {

--- a/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/AffixTuningParameters.cpp
@@ -25,6 +25,17 @@ public:
 
 private:
   LaunchDimensionCallback launchDimCallback;
+  // Block size can be set in two ways:
+  // * Through the MLIR lowering pass:
+  //   At this case, blockSizeOverride will be initialized to zero. Then
+  //   the affix tuning parameters pass will decide on a block size.
+  //   Finally, block size will be hinted back to mlir-miopen-driver.
+  // * Through cmd option "block_size":
+  //   At this case, mlir-miopen-driver assigns a blockSizeOverride. As
+  //   a result, affix tuning parameters pass should make its decisions
+  //   to generate tuning parameters based on this blockSizeOverride.
+  //   This guarantess that affix tuning parameters pass generate
+  //   coherent tuning parameters with the pre-set block size.
   int64_t blockSizeOverride;
 };
 } // anonymous namespace

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -419,7 +419,7 @@ static LogicalResult runMLIRPasses(ModuleOp &module, mlir::PassPipelineCLParser 
     pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
     pm.addPass(mlir::miopen::createAffineTransformPass());
     pm.addPass(mlir::miopen::createAffixTuningParametersPass(
-        [&](int64_t computedBlockSize, int64_t computedGridSize) {
+        blockSize, [&](int64_t computedBlockSize, int64_t computedGridSize) {
           // Use computed block size and grid size in case they are not
           // specified from command line.
           if (blockSize == 0)


### PR DESCRIPTION
This PR enables the following use case:

- When there's a blockSize override from mlir-miopen-driver, tuning parameter will check only blockSize that matches
- When there is not a blockSize override, affix params pass will hint back what the blockSize and gridSize it has chosen

Please note, since gridSize is dependent on blockSize, an override on gridSize will just be ignored. 