### PR TITLE
Adding libMLIRMIOpen.a for cpp generation API

### DIFF
--- a/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
+++ b/mlir/include/mlir/Dialect/MIOpen/LowerMIOpenOps.h
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#ifndef MLIR_DIALECT_MIOPEN_LOWERMIOPENOPS_H
+#define MLIR_DIALECT_MIOPEN_LOWERMIOPENOPS_H
+
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/GPU/GPUDialect.h"
@@ -914,42 +917,6 @@ struct Conv2DRewritePattern : public OpRewritePattern<T> {
     return success();
   }
 };
-
-// High level convolution operation always have
-// [filter, input, output]
-// as the convolution argument. The only difference between different
-// hight level convolution operations is the argument sequence. For
-// simplicity, we always arrange the first two arguments to be input
-// and the last argument to be output
-template <>
-const ArgumentFields Conv2DRewritePattern<miopen::Conv2DOp>::fields = {
-    {0, 1, 2},
-    {"KM", "KN", "MN"},
-};
-template <>
-const miopen::ConvOpType Conv2DRewritePattern<miopen::Conv2DOp>::convOpType =
-    miopen::ConvOpType::Conv2DOpType;
-
-template <>
-const ArgumentFields Conv2DRewritePattern<miopen::Conv2DBwdDataOp>::fields = {
-    {0, 2, 1},
-    {"KM", "MN", "KN"},
-};
-
-template <>
-const miopen::ConvOpType Conv2DRewritePattern<miopen::Conv2DBwdDataOp>::convOpType =
-miopen::ConvOpType::Conv2DBwdDataOpType;
-
-template <>
-const ArgumentFields Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>::fields = {
-	{2, 1, 0},
-	{"MN", "KN", "KM"},
-};
-
-template <>
-const miopen::ConvOpType Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>::convOpType =
-miopen::ConvOpType::Conv2DBwdWeightOpType;
-
 
 // Explicitly instantiate the template to operation type
 template struct Conv2DRewritePattern<miopen::Conv2DOp>;
@@ -3004,3 +2971,4 @@ struct TransformRewritePattern : public OpRewritePattern<miopen::TransformOp> {
     return success();
   }
 };
+#endif // MLIR_DIALECT_MIOPEN_LOWERMIOPENOPS_H

--- a/mlir/include/mlir/Target/MIOpenCPP.h
+++ b/mlir/include/mlir/Target/MIOpenCPP.h
@@ -27,17 +27,17 @@ class ModuleOp;
 /// Convert the given MLIR module into MIOpen C++ . In case of error, report it
 /// to the error handler registered with the MLIR context, if any (obtained from
 /// the MLIR module), and return `nullptr`.
-std::unique_ptr<llvm::StringRef> translateModuleToMIOpenCpp(ModuleOp m);
+void translateModuleToMIOpenCpp(ModuleOp m, std::string &source);
 
 /// Convert the given MLIR module into MIOpen C++ Header. In case of error, report it
 /// to the error handler registered with the MLIR context, if any (obtained from
 /// the MLIR module), and return `nullptr`.
-std::unique_ptr<llvm::StringRef> translateModuleToMIOpenHeader(ModuleOp m);
+void translateModuleToMIOpenHeader(ModuleOp m, std::string &header);
 
 /// Convert the given MLIR module into MIOpen C++ compilation flags. In case of error, report it
 /// to the error handler registered with the MLIR context, if any (obtained from
 /// the MLIR module), and return `nullptr`.
-std::unique_ptr<llvm::StringRef> translateModuleToMIOpenCFlags(ModuleOp m);
+void translateModuleToMIOpenCFlags(ModuleOp m, std::string &cflags);
 
 /// Convert the given MLIR module into MIOpen C++ . In case of error, report it
 /// to the error handler registered with the MLIR context, if any (obtained from

--- a/mlir/lib/Conversion/MIOpenToGPU/CMakeLists.txt
+++ b/mlir/lib/Conversion/MIOpenToGPU/CMakeLists.txt
@@ -10,6 +10,7 @@ add_mlir_conversion_library(MLIRMIOpenToGPU
 target_link_libraries(MLIRMIOpenToGPU
   PUBLIC
   MLIRAffineToStandard
+  MLIRMIOpenTransforms
   MLIRGPU
   MLIRLLVMIR
   MLIRIR

--- a/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
+++ b/mlir/lib/Dialect/MIOpen/Transforms/LowerMIOpenOps.cpp
@@ -71,6 +71,43 @@ struct LowerMIOpenOpsStep5Pass
 };
 } // end anonymous namespace
 
+// High level convolution operation always have
+// [filter, input, output]
+// as the convolution argument. The only difference between different
+// hight level convolution operations is the argument sequence. For
+// simplicity, we always arrange the first two arguments to be input
+// and the last argument to be output
+template <>
+const ArgumentFields Conv2DRewritePattern<miopen::Conv2DOp>::fields = {
+    {0, 1, 2},
+    {"KM", "KN", "MN"},
+};
+template <>
+const miopen::ConvOpType Conv2DRewritePattern<miopen::Conv2DOp>::convOpType =
+    miopen::ConvOpType::Conv2DOpType;
+
+template <>
+const ArgumentFields Conv2DRewritePattern<miopen::Conv2DBwdDataOp>::fields = {
+    {0, 2, 1},
+    {"KM", "MN", "KN"},
+};
+
+template <>
+const miopen::ConvOpType
+    Conv2DRewritePattern<miopen::Conv2DBwdDataOp>::convOpType =
+        miopen::ConvOpType::Conv2DBwdDataOpType;
+
+template <>
+const ArgumentFields Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>::fields = {
+    {2, 1, 0},
+    {"MN", "KN", "KM"},
+};
+
+template <>
+const miopen::ConvOpType
+    Conv2DRewritePattern<miopen::Conv2DBwdWeightOp>::convOpType =
+        miopen::ConvOpType::Conv2DBwdWeightOpType;
+
 void LowerMIOpenOpsStep1Pass::runOnOperation() {
   OwningRewritePatternList patterns;
   patterns.insert<Conv2DRewritePattern<miopen::Conv2DOp>>(&getContext());

--- a/mlir/lib/Target/CppOutput/ConvertToMIOpenCPP.cpp
+++ b/mlir/lib/Target/CppOutput/ConvertToMIOpenCPP.cpp
@@ -40,36 +40,33 @@ cl::opt<bool> IsPopulateTunableParameters("populate-tunable-parameters-to-yaml-f
 namespace mlir {
 void registerToMIOpenCPPTranslation() {
   // non-XDLOPS kernel generation.
-  TranslateFromMLIRRegistration
-      toCpp("mlir-to-miopen-cpp", [](ModuleOp module, llvm::raw_ostream &output) {
-        auto sourceCode = mlir::translateModuleToMIOpenCpp(module);
-        if (!sourceCode)
-          return failure();
-  
-        output << *sourceCode;
+  TranslateFromMLIRRegistration toCpp(
+      "mlir-to-miopen-cpp", [](ModuleOp module, llvm::raw_ostream &output) {
+        std::string source;
+        mlir::translateModuleToMIOpenCpp(module, source);
+
+        output << source;
         return success();
       });
-  
-  TranslateFromMLIRRegistration
-      toHeader("mlir-to-miopen-hpp", [](ModuleOp module, llvm::raw_ostream &output) {
-        auto sourceCode = mlir::translateModuleToMIOpenHeader(module);
-        if (!sourceCode)
-          return failure();
-  
-        output << *sourceCode;
+
+  TranslateFromMLIRRegistration toHeader(
+      "mlir-to-miopen-hpp", [](ModuleOp module, llvm::raw_ostream &output) {
+        std::string header;
+        mlir::translateModuleToMIOpenHeader(module, header);
+
+        output << header;
         return success();
       });
-  
-  TranslateFromMLIRRegistration
-      toCFlags("mlir-to-miopen-cflags", [](ModuleOp module, llvm::raw_ostream &output) {
-        auto sourceCode = mlir::translateModuleToMIOpenCFlags(module);
-        if (!sourceCode)
-          return failure();
-  
-        output << *sourceCode;
+
+  TranslateFromMLIRRegistration toCFlags(
+      "mlir-to-miopen-cflags", [](ModuleOp module, llvm::raw_ostream &output) {
+        std::string cflags;
+        mlir::translateModuleToMIOpenCFlags(module, cflags);
+
+        output << cflags;
         return success();
       });
-  
+
   // XDLOPS kernel generation.
   TranslateFromMLIRRegistration
       toCppXDLOPS("mlir-to-miopen-cpp-xdlops", [](ModuleOp module, llvm::raw_ostream &output) {

--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -28,9 +28,6 @@
 using namespace mlir;
 
 namespace {
-// result string to keep C++ source / header / flags emission.
-std::string resultStr;
-
 static constexpr StringLiteral kVarArgName[3] = {"p_wei_global", "p_in_global",
                                                  "p_out_global"};
 
@@ -684,8 +681,8 @@ static void ObtainModuleInfo(ModuleOp &m,
 
 } // namespace
 
-std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeader(ModuleOp m) {
-  llvm::raw_string_ostream output(resultStr);
+void mlir::translateModuleToMIOpenHeader(ModuleOp m, std::string &header) {
+  llvm::raw_string_ostream output(header);
 
   // Enumerate FuncOp instances inside the ModuleOp.
   for (auto f : m.getOps<FuncOp>()) {
@@ -865,11 +862,10 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenHeader(ModuleOp m)
   }
 
   output.flush();
-  return std::make_unique<llvm::StringRef>(resultStr);
 }
 
-std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCpp(ModuleOp m) {
-  llvm::raw_string_ostream output(resultStr);
+void mlir::translateModuleToMIOpenCpp(ModuleOp m, std::string &source) {
+  llvm::raw_string_ostream output(source);
 
   // Enumerate FuncOp instances inside the ModuleOp.
   for (auto f : m.getOps<FuncOp>()) {
@@ -912,11 +908,10 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCpp(ModuleOp m) {
   }
 
   output.flush();
-  return std::make_unique<llvm::StringRef>(resultStr);
 }
 
-std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlags(ModuleOp m) {
-  llvm::raw_string_ostream output(resultStr);
+void mlir::translateModuleToMIOpenCFlags(ModuleOp m, std::string &cflags) {
+  llvm::raw_string_ostream output(cflags);
 
   for (auto f : m.getOps<FuncOp>()) {
     output << f.getName() << "\n";
@@ -1049,5 +1044,4 @@ std::unique_ptr<llvm::StringRef> mlir::translateModuleToMIOpenCFlags(ModuleOp m)
   }
  
   output.flush();
-  return std::make_unique<llvm::StringRef>(resultStr);
 }

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -81,6 +81,7 @@ endif()
 if(MLIR_MIOPEN_DRIVER_ENABLED)
   list(APPEND MLIR_TEST_DEPENDS
     mlir-miopen-driver
+    mlir-miopen-lib-test
     mlir-translate
     opt
     llc

--- a/mlir/test/mlir-miopen-lib/populate_bwd.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bwd.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option cflags | FileCheck %s --check-prefix=CFLAGS
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option source | FileCheck %s --check-prefix=SOURCE
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
+
+// CFLAGS: miopen_conv2d_bwd_data_kcyx_nchw_nkhw
+// SOURCE: void gridwise_convolution_backward_data_implicit_gemm_v1r1_mlir
+// HEADER: struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_mlir 

--- a/mlir/test/mlir-miopen-lib/populate_bww.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bww.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option cflags | FileCheck %s --check-prefix=CFLAGS
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option source | FileCheck %s --check-prefix=SOURCE
+// RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
+
+// CFLAGS: miopen_conv2d_bwd_weight_kcyx_nchw_nkhw
+// SOURCE: void gridwise_convolution_backward_weight_implicit_gemm_v4r4_mlir
+// HEADER: struct GridwiseConvolutionBackwardWeightImplicitGemm_v4r4_mlir 

--- a/mlir/test/mlir-miopen-lib/populate_fw.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_fw.mlir
@@ -1,0 +1,7 @@
+// RUN: mlir-miopen-lib-test --args " --operation conv2d --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option cflags | FileCheck %s --check-prefix=CFLAGS
+// RUN: mlir-miopen-lib-test --args " --operation conv2d --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option source | FileCheck %s --check-prefix=SOURCE
+// RUN: mlir-miopen-lib-test --args " --operation conv2d --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
+
+// CFLAGS: miopen_conv2d_kcyx_nchw_nkhw
+// SOURCE: void gridwise_convolution_implicit_gemm_v4r4_mlir
+// HEADER: struct GridwiseConvolutionImplicitGemm_v4r4_mlir 

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -31,7 +31,6 @@ add_llvm_executable(mlir-miopen-driver
   ${LIBS}
 )
 
-#llvm_add_library(MLIRMIOpenThin STATIC
 llvm_add_library(MLIRMIOpenThin STATIC
 #add_llvm_executable(MLIRMIOpen
 PARTIAL_SOURCES_INTENDED

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -31,22 +31,24 @@ add_llvm_executable(mlir-miopen-driver
   ${LIBS}
 )
 
-llvm_add_library(MLIRMIOpenThin STATIC
-#add_llvm_executable(MLIRMIOpen
-PARTIAL_SOURCES_INTENDED
-
-  mlir-miopen-lib.cpp
-
-  #DEPENDS
-  LINK_LIBS
-  ${LIBS}
-  )
-
 llvm_update_compile_flags(mlir-miopen-driver)
 target_link_libraries(mlir-miopen-driver PRIVATE ${LIBS})
 mlir_check_link_libraries(mlir-miopen-driver)
 
-function(combine_archives output_archive)
+# Static library target, enabled only when building static libs
+if( NOT BUILD_SHARED_LIBS )
+  llvm_add_library(MLIRMIOpenThin STATIC
+  #add_llvm_executable(MLIRMIOpen
+  PARTIAL_SOURCES_INTENDED
+  
+    mlir-miopen-lib.cpp
+  
+    #DEPENDS
+    LINK_LIBS
+    ${LIBS}
+    )
+
+  function(combine_archives output_archive)
     set(mri_file ${CMAKE_CURRENT_BINARY_DIR}/${output_archive}.mri)
     set(full_output_path ${LLVM_LIBRARY_DIR}/lib${output_archive}.a)
     set(output_archive_dummy_file ./${output_archive}.dummy.cpp)
@@ -73,11 +75,12 @@ function(combine_archives output_archive)
                        COMMAND ${CMAKE_AR} -M < ${mri_file}
                        COMMAND ${CMAKE_COMMAND} -E copy ${full_output_path} ${install_path}
                        DEPENDS ${output_archive_dummy_file})
-endfunction(combine_archives)
-
-combine_archives(MLIRMIOpen)
-
-add_custom_target(libMLIRMIOpen ALL
-  DEPENDS
-  MLIRMIOpen
-  )
+  endfunction(combine_archives)
+  
+  combine_archives(MLIRMIOpen)
+  
+  add_custom_target(libMLIRMIOpen ALL
+    DEPENDS
+    MLIRMIOpen
+    )
+endif()

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -33,7 +33,7 @@ add_llvm_executable(mlir-miopen-driver
 
 #llvm_add_library(MLIRMIOpenThin STATIC
 llvm_add_library(MLIRMIOpenThin STATIC
-#add_llvm_executable(MLIRMIOpen 
+#add_llvm_executable(MLIRMIOpen
 PARTIAL_SOURCES_INTENDED
 
   mlir-miopen-lib.cpp
@@ -47,18 +47,38 @@ llvm_update_compile_flags(mlir-miopen-driver)
 target_link_libraries(mlir-miopen-driver PRIVATE ${LIBS})
 mlir_check_link_libraries(mlir-miopen-driver)
 
-llvm_update_compile_flags(MLIRMIOpenThin)
-target_link_libraries(MLIRMIOpenThin PUBLIC ${LIBS})
-mlir_check_link_libraries(MLIRMIOpenThin)
+function(combine_archives output_archive)
+    set(mri_file ${CMAKE_CURRENT_BINARY_DIR}/${output_archive}.mri)
+    set(full_output_path ${LLVM_LIBRARY_DIR}/lib${output_archive}.a)
+    set(output_archive_dummy_file ./${output_archive}.dummy.cpp)
+    set(install_path /opt/rocm/lib/lib${output_archive}.a)
 
-add_custom_command(
-  OUTPUT libMLIRMIOpen.a
-  COMMAND ${CMAKE_AR} -cqT libMLIRMIOpen.a ${LLVM_LIBRARY_DIR}/*.a
-  COMMAND cp libMLIRMIOpen.a ${LLVM_LIBRARY_DIR}
-  )
+    # Step one: construct mri file.
+    add_custom_command(OUTPUT ${output_archive_dummy_file}
+                       COMMAND if [ -f ${output_archive}.mri ]\; then rm ${output_archive}.mri\; fi
+                       COMMAND touch ${output_archive}.mri
+                       COMMAND echo "create ${full_output_path}" >> ${output_archive}.mri
+                       COMMAND for archive in ${LLVM_LIBRARY_DIR}/*.a\; 
+                       do echo "addlib $$archive" >> ${output_archive}.mri \; done
+                       COMMAND echo "save" >> ${output_archive}.mri
+                       COMMAND echo "end" >> ${output_archive}.mri
+                       COMMAND touch ${output_archive_dummy_file}
+                       DEPENDS MLIRMIOpenThin)
+
+    # Step two: use mri file to generate the fat library.
+    llvm_add_library(${output_archive}
+      PARTIAL_SOURCES_INTENDED
+      STATIC ${output_archive_dummy_file})
+    add_custom_command(TARGET ${output_archive}
+                       POST_BUILD
+                       COMMAND ${CMAKE_AR} -M < ${mri_file}
+                       COMMAND ${CMAKE_COMMAND} -E copy ${full_output_path} ${install_path}
+                       DEPENDS ${output_archive_dummy_file})
+endfunction(combine_archives)
+
+combine_archives(MLIRMIOpen)
 
 add_custom_target(libMLIRMIOpen ALL
-  DEPENDS 
-  libMLIRMIOpen.a
-  MLIRMIOpenThin
+  DEPENDS
+  MLIRMIOpen
   )

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -19,15 +19,46 @@ set(LIBS
   MLIRTransforms
   MLIRSupport
   MLIRIR
+  MLIRTargetMIOpenCppTranslation
 )
 
 add_llvm_executable(mlir-miopen-driver
+  PARTIAL_SOURCES_INTENDED
+
   mlir-miopen-driver.cpp
 
   DEPENDS
   ${LIBS}
 )
+
+#llvm_add_library(MLIRMIOpenThin STATIC
+llvm_add_library(MLIRMIOpenThin STATIC
+#add_llvm_executable(MLIRMIOpen 
+PARTIAL_SOURCES_INTENDED
+
+  mlir-miopen-lib.cpp
+
+  #DEPENDS
+  LINK_LIBS
+  ${LIBS}
+  )
+
 llvm_update_compile_flags(mlir-miopen-driver)
 target_link_libraries(mlir-miopen-driver PRIVATE ${LIBS})
-
 mlir_check_link_libraries(mlir-miopen-driver)
+
+llvm_update_compile_flags(MLIRMIOpenThin)
+target_link_libraries(MLIRMIOpenThin PUBLIC ${LIBS})
+mlir_check_link_libraries(MLIRMIOpenThin)
+
+add_custom_command(
+  OUTPUT libMLIRMIOpen.a
+  COMMAND ${CMAKE_AR} -cqT libMLIRMIOpen.a ${LLVM_LIBRARY_DIR}/*.a
+  COMMAND cp libMLIRMIOpen.a ${LLVM_LIBRARY_DIR}
+  )
+
+add_custom_target(libMLIRMIOpen ALL
+  DEPENDS 
+  libMLIRMIOpen.a
+  MLIRMIOpenThin
+  )

--- a/mlir/tools/mlir-miopen-driver/CMakeLists.txt
+++ b/mlir/tools/mlir-miopen-driver/CMakeLists.txt
@@ -35,19 +35,32 @@ llvm_update_compile_flags(mlir-miopen-driver)
 target_link_libraries(mlir-miopen-driver PRIVATE ${LIBS})
 mlir_check_link_libraries(mlir-miopen-driver)
 
-# Static library target, enabled only when building static libs
-if( NOT BUILD_SHARED_LIBS )
-  llvm_add_library(MLIRMIOpenThin STATIC
-  #add_llvm_executable(MLIRMIOpen
+
+  llvm_add_library(MLIRMIOpenThin
   PARTIAL_SOURCES_INTENDED
   
     mlir-miopen-lib.cpp
   
-    #DEPENDS
     LINK_LIBS
     ${LIBS}
     )
 
+add_llvm_executable(mlir-miopen-lib-test
+  PARTIAL_SOURCES_INTENDED
+
+  mlir-miopen-lib-test.cpp
+
+  DEPENDS
+  MLIRMIOpenThin
+  ${LIBS}
+)
+
+llvm_update_compile_flags(mlir-miopen-lib-test)
+target_link_libraries(mlir-miopen-lib-test PRIVATE MLIRMIOpenThin ${LIBS})
+mlir_check_link_libraries(mlir-miopen-lib-test)
+
+# Static library target, enabled only when building static libs
+if( NOT BUILD_SHARED_LIBS )
   function(combine_archives output_archive)
     set(mri_file ${CMAKE_CURRENT_BINARY_DIR}/${output_archive}.mri)
     set(full_output_path ${LLVM_LIBRARY_DIR}/lib${output_archive}.a)

--- a/mlir/tools/mlir-miopen-driver/MlirParse.h
+++ b/mlir/tools/mlir-miopen-driver/MlirParse.h
@@ -1,0 +1,195 @@
+//===- MlirParse.h - MLIR to C++ option parsing ---------------===//
+//
+// Part of the MLIR Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares mlir convolution option parsing logic
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_TOOLS_MLIR_MIOPEN_DRIVER_MLIRPARSE_H_
+#define MLIR_TOOLS_MLIR_MIOPEN_DRIVER_MLIRPARSE_H_
+
+#include "mlir/Dialect/MIOpen/MIOpenOps.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Function.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Module.h"
+#include "mlir/IR/StandardTypes.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+
+static LogicalResult populateConvolutionConfiguration(
+    std::string &inputLayout, std::string &outputLayout,
+    std::string &filterLayout, int64_t batchSize, int64_t inputChannel,
+    int64_t inputHeight, int64_t inputWidth, int64_t outputChannel,
+    int64_t outputHeight, int64_t outputWidth, int64_t filterWidth,
+    int64_t filterHeight, SmallVector<int64_t, 4> &filterDimension,
+    SmallVector<int64_t, 4> &inputDimension,
+    SmallVector<int64_t, 4> &outputDimension) {
+  // Determine dimensions.
+  for (size_t i = 0; i < 4; ++i) {
+    auto &filterDim = filterLayout[i];
+    auto &inputDim = inputLayout[i];
+    auto &outputDim = outputLayout[i];
+
+    if (filterDim == 'k') {
+      filterDimension.push_back(outputChannel);
+    } else if (filterDim == 'c') {
+      filterDimension.push_back(inputChannel);
+    } else if (filterDim == 'y') {
+      filterDimension.push_back(filterWidth);
+    } else if (filterDim == 'x') {
+      filterDimension.push_back(filterHeight);
+    }
+
+    if (inputDim == 'n') {
+      inputDimension.push_back(batchSize);
+    } else if (inputDim == 'c') {
+      inputDimension.push_back(inputChannel);
+    } else if (inputDim == 'h') {
+      inputDimension.push_back(inputWidth);
+    } else if (inputDim == 'w') {
+      inputDimension.push_back(inputHeight);
+    }
+
+    if (outputDim == 'n') {
+      outputDimension.push_back(batchSize);
+    } else if (outputDim == 'k') {
+      outputDimension.push_back(outputChannel);
+    } else if (outputDim == 'h') {
+      outputDimension.push_back(outputWidth);
+    } else if (outputDim == 'w') {
+      outputDimension.push_back(outputHeight);
+    }
+  }
+
+  return success();
+}
+
+static LogicalResult populateConvolutionLogic(
+    std::string &operation, std::string &inputLayout, std::string &outputLayout,
+    std::string &filterLayout, int64_t batchSize, int64_t inputChannel,
+    int64_t inputHeight, int64_t inputWidth, int64_t outputChannel,
+    int64_t outputHeight, int64_t outputWidth, int64_t filterWidth,
+    int64_t filterHeight, int64_t dilationHeight, int64_t dilationWidth,
+    int64_t strideHeight, int64_t strideWidth, int64_t paddingHeight,
+    int64_t paddingWidth, ModuleOp &module, OpBuilder &builder,
+    SmallString<128> &kernelName) {
+  // Determine dimensions.
+  SmallVector<int64_t, 4> filterDimension;
+  SmallVector<int64_t, 4> inputDimension;
+  SmallVector<int64_t, 4> outputDimension;
+  populateConvolutionConfiguration(
+      inputLayout, outputLayout, filterLayout, batchSize, inputChannel,
+      inputHeight, inputWidth, outputChannel, outputHeight, outputWidth,
+      filterWidth, filterHeight, filterDimension, inputDimension,
+      outputDimension);
+
+  // Construct a new FuncOp.
+  auto filterArgType = MemRefType::get(
+      ArrayRef<int64_t>(filterDimension.begin(), filterDimension.end()),
+      builder.getF32Type());
+  auto inputArgType = MemRefType::get(
+      ArrayRef<int64_t>(inputDimension.begin(), inputDimension.end()),
+      builder.getF32Type());
+  auto outputArgType = MemRefType::get(
+      ArrayRef<int64_t>(outputDimension.begin(), outputDimension.end()),
+      builder.getF32Type());
+  auto funcType =
+      builder.getFunctionType({filterArgType, inputArgType, outputArgType}, {});
+
+  // Determine kernel name.
+  kernelName = "miopen_" + operation + "_" + filterLayout + "_" + inputLayout +
+               "_" + outputLayout;
+
+  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType);
+  module.push_back(func);
+
+  // Construct a new Block.
+  Block *block = func.addEntryBlock();
+
+  // Construct a new Conv2DOp.
+  SmallVector<StringAttr, 4> filterLayoutSpec;
+  SmallVector<StringAttr, 4> inputLayoutSpec;
+  SmallVector<StringAttr, 4> outputLayoutSpec;
+  for (size_t i = 0; i < 4; ++i) {
+    filterLayoutSpec.push_back(
+        builder.getStringAttr(StringRef(&filterLayout[i], 1)));
+    inputLayoutSpec.push_back(
+        builder.getStringAttr((StringRef(&inputLayout[i], 1) + "i").str()));
+    outputLayoutSpec.push_back(
+        builder.getStringAttr((StringRef(&outputLayout[i], 1) + "o").str()));
+  }
+
+  std::vector<NamedAttribute> attributes{
+      builder.getNamedAttr(
+          "filter_layout",
+          builder.getArrayAttr(ArrayRef<mlir::Attribute>(
+              filterLayoutSpec.begin(), filterLayoutSpec.end()))),
+      builder.getNamedAttr(
+          "input_layout", builder.getArrayAttr(ArrayRef<mlir::Attribute>(
+                              inputLayoutSpec.begin(), inputLayoutSpec.end()))),
+      builder.getNamedAttr(
+          "output_layout",
+          builder.getArrayAttr(ArrayRef<mlir::Attribute>(
+              outputLayoutSpec.begin(), outputLayoutSpec.end()))),
+
+      builder.getNamedAttr("dilations",
+                           builder.getArrayAttr({
+                               builder.getI32IntegerAttr(dilationHeight),
+                               builder.getI32IntegerAttr(dilationWidth),
+                           })),
+      builder.getNamedAttr("strides",
+                           builder.getArrayAttr({
+                               builder.getI32IntegerAttr(strideHeight),
+                               builder.getI32IntegerAttr(strideWidth),
+                           })),
+      builder.getNamedAttr("padding",
+                           builder.getArrayAttr({
+                               builder.getI32IntegerAttr(paddingHeight),
+                               builder.getI32IntegerAttr(paddingWidth),
+                           })),
+  };
+
+  if (operation.compare("conv2d") == 0) {
+    auto convOp = builder.create<miopen::Conv2DOp>(
+        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
+        ValueRange{func.getArgument(0), func.getArgument(1),
+                   func.getArgument(2)},
+        attributes);
+    block->push_front(convOp);
+  } else if (operation.compare("conv2d_bwd_data") == 0) {
+    auto convOp = builder.create<miopen::Conv2DBwdDataOp>(
+        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
+        ValueRange{func.getArgument(0), func.getArgument(1),
+                   func.getArgument(2)},
+        attributes);
+    block->push_front(convOp);
+  } else if (operation.compare("conv2d_bwd_weight") == 0) {
+    auto convOp = builder.create<miopen::Conv2DBwdWeightOp>(
+        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
+        ValueRange{func.getArgument(0), func.getArgument(1),
+                   func.getArgument(2)},
+        attributes);
+    block->push_back(convOp);
+  }
+
+  auto returnOp =
+      builder.create<ReturnOp>(builder.getUnknownLoc(), ValueRange{});
+  block->push_back(returnOp);
+
+  return success();
+}
+
+} // namespace mlir
+#endif // MLIR_TOOLS_MLIR_MIOPEN_DRIVER_MLIRPARSE_H_

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-driver.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "MlirParse.h"
 #include "mlir/Dialect/MIOpen/MIOpenOps.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
@@ -170,12 +171,8 @@ static cl::opt<int> blockSize("block_size", cl::desc("Block size"),
 static cl::opt<int> gridSize("grid_size", cl::desc("Grid size"),
                              cl::value_desc("Grid size"), cl::init(0));
 
-static LogicalResult
-populateConvolutionConfiguration(SmallVector<int64_t, 4> &filterDimension,
-                                 SmallVector<int64_t, 4> &inputDimension,
-                                 SmallVector<int64_t, 4> &outputDimension) {
-  // Populate default parameters if necessary.
-  if (populateDefaultValues.getValue() == true) {
+static void populateDefaults() {
+  if (populateDefaultValues == true) {
     batchSize.setValue(128);
     inputChannel.setValue(8);
     outputChannel.setValue(128);
@@ -192,45 +189,6 @@ populateConvolutionConfiguration(SmallVector<int64_t, 4> &filterDimension,
     paddingHeight.setValue(0);
     paddingWidth.setValue(0);
   }
-
-  // Determine dimensions.
-  for (size_t i = 0; i < 4; ++i) {
-    auto &filterDim = filterLayout.getValue()[i];
-    auto &inputDim = inputLayout.getValue()[i];
-    auto &outputDim = outputLayout.getValue()[i];
-
-    if (filterDim == 'k') {
-      filterDimension.push_back(outputChannel.getValue());
-    } else if (filterDim == 'c') {
-      filterDimension.push_back(inputChannel.getValue());
-    } else if (filterDim == 'y') {
-      filterDimension.push_back(filterWidth.getValue());
-    } else if (filterDim == 'x') {
-      filterDimension.push_back(filterHeight.getValue());
-    }
-
-    if (inputDim == 'n') {
-      inputDimension.push_back(batchSize.getValue());
-    } else if (inputDim == 'c') {
-      inputDimension.push_back(inputChannel.getValue());
-    } else if (inputDim == 'h') {
-      inputDimension.push_back(inputWidth.getValue());
-    } else if (inputDim == 'w') {
-      inputDimension.push_back(inputHeight.getValue());
-    }
-
-    if (outputDim == 'n') {
-      outputDimension.push_back(batchSize.getValue());
-    } else if (outputDim == 'k') {
-      outputDimension.push_back(outputChannel.getValue());
-    } else if (outputDim == 'h') {
-      outputDimension.push_back(outputWidth.getValue());
-    } else if (outputDim == 'w') {
-      outputDimension.push_back(outputHeight.getValue());
-    }
-  }
-
-  return success();
 }
 
 static LogicalResult populateHostHarnessLogic(ModuleOp &module, OpBuilder &builder,
@@ -246,8 +204,12 @@ static LogicalResult populateHostHarnessLogic(ModuleOp &module, OpBuilder &build
   SmallVector<int64_t, 4> filterDimension;
   SmallVector<int64_t, 4> inputDimension;
   SmallVector<int64_t, 4> outputDimension;
-  populateConvolutionConfiguration(filterDimension, inputDimension,
-                                   outputDimension);
+  populateConvolutionConfiguration(
+      inputLayout.getValue(), outputLayout.getValue(), filterLayout.getValue(),
+      batchSize.getValue(), inputChannel.getValue(), inputHeight.getValue(),
+      inputWidth.getValue(), outputChannel.getValue(), outputHeight.getValue(),
+      outputWidth.getValue(), filterWidth.getValue(), filterHeight.getValue(),
+      filterDimension, inputDimension, outputDimension);
 
   auto filterMemRefType = MemRefType::get(
       ArrayRef<int64_t>(filterDimension.begin(), filterDimension.end()),
@@ -523,110 +485,6 @@ static LogicalResult populateKernelLaunchLogic(ModuleOp &module,
   return success();
 }
 
-static LogicalResult populateConvolutionLogic(ModuleOp &module,
-                                              OpBuilder &builder,
-                                              MLIRContext &context,
-                                              SmallString<128> &kernelName) {
-  // Determine dimensions.
-  SmallVector<int64_t, 4> filterDimension;
-  SmallVector<int64_t, 4> inputDimension;
-  SmallVector<int64_t, 4> outputDimension;
-  populateConvolutionConfiguration(filterDimension, inputDimension,
-                                   outputDimension);
-
-  // Construct a new FuncOp.
-  auto filterArgType = MemRefType::get(
-      ArrayRef<int64_t>(filterDimension.begin(), filterDimension.end()),
-      builder.getF32Type());
-  auto inputArgType = MemRefType::get(
-      ArrayRef<int64_t>(inputDimension.begin(), inputDimension.end()),
-      builder.getF32Type());
-  auto outputArgType = MemRefType::get(
-      ArrayRef<int64_t>(outputDimension.begin(), outputDimension.end()),
-      builder.getF32Type());
-  auto funcType =
-      builder.getFunctionType({filterArgType, inputArgType, outputArgType}, {});
-
-  // Determine kernel name.
-  kernelName = "miopen_" + operation.getValue() + "_" + filterLayout + "_" +
-               inputLayout + "_" + outputLayout;
-
-  auto func = FuncOp::create(builder.getUnknownLoc(), kernelName, funcType);
-  module.push_back(func);
-
-  // Construct a new Block.
-  Block *block = func.addEntryBlock();
-
-  // Construct a new Conv2DOp.
-  SmallVector<StringAttr, 4> filterLayoutSpec;
-  SmallVector<StringAttr, 4> inputLayoutSpec;
-  SmallVector<StringAttr, 4> outputLayoutSpec;
-  for (size_t i = 0; i < 4; ++i) {
-    filterLayoutSpec.push_back(builder.getStringAttr(StringRef(&filterLayout.getValue()[i], 1)));
-    inputLayoutSpec.push_back(builder.getStringAttr((StringRef(&inputLayout.getValue()[i], 1) + "i").str()));
-    outputLayoutSpec.push_back(builder.getStringAttr((StringRef(&outputLayout.getValue()[i], 1) + "o").str()));
-  }
-
-  std::vector<NamedAttribute> attributes{
-      builder.getNamedAttr(
-          "filter_layout",
-          builder.getArrayAttr(ArrayRef<mlir::Attribute>(
-              filterLayoutSpec.begin(), filterLayoutSpec.end()))),
-      builder.getNamedAttr(
-          "input_layout", builder.getArrayAttr(ArrayRef<mlir::Attribute>(
-                              inputLayoutSpec.begin(), inputLayoutSpec.end()))),
-      builder.getNamedAttr(
-          "output_layout",
-          builder.getArrayAttr(ArrayRef<mlir::Attribute>(
-              outputLayoutSpec.begin(), outputLayoutSpec.end()))),
-
-      builder.getNamedAttr(
-          "dilations", builder.getArrayAttr({
-                           builder.getI32IntegerAttr(dilationHeight.getValue()),
-                           builder.getI32IntegerAttr(dilationWidth.getValue()),
-                       })),
-      builder.getNamedAttr(
-          "strides", builder.getArrayAttr({
-                         builder.getI32IntegerAttr(strideHeight.getValue()),
-                         builder.getI32IntegerAttr(strideWidth.getValue()),
-                     })),
-      builder.getNamedAttr(
-          "padding", builder.getArrayAttr({
-                         builder.getI32IntegerAttr(paddingHeight.getValue()),
-                         builder.getI32IntegerAttr(paddingWidth.getValue()),
-                     })),
-  };
-
-  if (operation.getValue().compare("conv2d") == 0) {
-    auto convOp = builder.create<miopen::Conv2DOp>(
-        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
-        ValueRange{func.getArgument(0), func.getArgument(1),
-                   func.getArgument(2)},
-        attributes);
-    block->push_front(convOp);
-  } else if (operation.getValue().compare("conv2d_bwd_data") == 0) {
-    auto convOp = builder.create<miopen::Conv2DBwdDataOp>(
-        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
-        ValueRange{func.getArgument(0), func.getArgument(1),
-                   func.getArgument(2)},
-        attributes);
-    block->push_front(convOp);
-  } else if (operation.getValue().compare("conv2d_bwd_weight") == 0) {
-    auto convOp = builder.create<miopen::Conv2DBwdWeightOp>(
-        builder.getUnknownLoc(), ArrayRef<mlir::Type>{},
-        ValueRange{func.getArgument(0), func.getArgument(1),
-                   func.getArgument(2)},
-        attributes);
-    block->push_back(convOp);
-  }
-
-  auto returnOp =
-      builder.create<ReturnOp>(builder.getUnknownLoc(), ValueRange{});
-  block->push_back(returnOp);
-
-  return success();
-}
-
 static LogicalResult runMLIRPasses(ModuleOp &module, mlir::PassPipelineCLParser &passPipeline, StringRef kernelName) {
   PassManager pm(module.getContext());
   applyPassManagerCLOptions(pm);
@@ -707,7 +565,18 @@ int main(int argc, char **argv) {
 
   // Populate the module.
   SmallString<128> kernelName;
-  if (failed(populateConvolutionLogic(module, builder, context, kernelName))) {
+  populateDefaults();
+  if (failed(populateConvolutionLogic(
+          operation.getValue(), inputLayout.getValue(), outputLayout.getValue(),
+          filterLayout.getValue(), batchSize.getValue(),
+          inputChannel.getValue(), inputHeight.getValue(),
+          inputWidth.getValue(), outputChannel.getValue(),
+          outputHeight.getValue(), outputWidth.getValue(),
+          filterWidth.getValue(), filterHeight.getValue(),
+          dilationHeight.getValue(), dilationWidth.getValue(),
+          strideHeight.getValue(), strideWidth.getValue(),
+          paddingHeight.getValue(), paddingWidth.getValue(), module, builder,
+          kernelName))) {
     llvm::errs() << "Module population failed.\n";
     exit(1);
   }

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-lib-test.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-lib-test.cpp
@@ -1,0 +1,40 @@
+#include "mlir-miopen-lib.hpp"
+#include "llvm/Support/CommandLine.h"
+#include <iostream>
+#include <string>
+
+using namespace llvm;
+static cl::opt<std::string> args(
+    "args", cl::desc("Convolution args"),
+    cl::value_desc("Igemm convolution args string"),
+    cl::init(
+        R"( --operation conv2d_bwd_weight --fil_layout kcyx )"
+        R"(--in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 )"
+        R"(--out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 )"
+        R"(--fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 )"
+        R"(--conv_stride_w 1 --padding_h 0 --padding_w 0)"));
+
+static cl::opt<std::string>
+    option("option", cl::desc("Code gen options: source/header/cflags"),
+           cl::value_desc("Igemm convolution option string"),
+           cl::init("source"));
+
+int main(int argc, char **argv) {
+  // Parse pass names in main to ensure static initialization completed.
+  cl::ParseCommandLineOptions(argc, argv, "MLIR MIOpen Dialect driver\n");
+
+  mlir::MlirHandle handle = mlir::CreateMlirHandle(args.getValue().c_str());
+
+  if (option.getValue() == "source") {
+    std::string source = mlir::MlirGenIgemmSource(handle);
+    std::cout << source << std::endl;
+  } else if (option.getValue() == "header") {
+    std::string header = mlir::MlirGenIgemmHeader(handle);
+    std::cout << header << std::endl;
+  } else if (option.getValue() == "cflags") {
+    std::string cflags = mlir::MlirGenIgemmCflags(handle);
+    std::cout << cflags << std::endl;
+  }
+
+  mlir::DestroyMlirHandle(handle);
+}

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.cpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.cpp
@@ -1,0 +1,115 @@
+#include "MlirParse.h"
+#include "mlir/Dialect/MIOpen/LowerMIOpenOps.h"
+#include "mlir/Dialect/MIOpen/Passes.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Module.h"
+#include "mlir/Target/MIOpenCPP.h"
+
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+
+namespace mlir {
+namespace {
+struct MlirHandle_s {
+  MlirHandle_s() {
+    OpBuilder builder(&context);
+    module = ModuleOp::create(builder.getUnknownLoc());
+  }
+  MLIRContext context;
+  ModuleOp module;
+};
+
+static void strToTokens(const std::string &arguments,
+                        std::map<std::string, std::string> &argMap) {
+  std::istringstream iss(arguments);
+  std::string token;
+  std::string argKey;
+  std::string argVal;
+  while (std::getline(iss, token, ' ')) {
+    auto pos = token.find("--");
+    if (pos != std::string::npos) {
+      argKey = token.substr(pos + 2, token.size());
+    } else {
+      argVal = token;
+      if (argKey.empty() || argVal.empty())
+        continue;
+      argMap[argKey] = argVal;
+    }
+  }
+}
+} // namespace
+
+typedef void *MlirHandle;
+
+extern "C" MlirHandle CreateMlirHandle(const char *arguments) {
+  registerDialect<miopen::MIOpenDialect>();
+  registerDialect<StandardOpsDialect>();
+
+  MlirHandle_s *handle = new MlirHandle_s();
+  OpBuilder builder(&(handle->context));
+
+  std::map<std::string, std::string> argMap;
+  strToTokens(arguments, argMap);
+
+  auto strToLong = [&argMap](std::string argKey) {
+    return std::stoul(argMap[argKey]);
+  };
+
+  SmallString<128> kernelName;
+  populateConvolutionLogic(
+      argMap["operation"], argMap["in_layout"], argMap["out_layout"],
+      argMap["fil_layout"], strToLong("batchsize"), strToLong("in_channels"),
+      strToLong("in_h"), strToLong("in_w"), strToLong("out_channels"),
+      strToLong("out_h"), strToLong("out_w"), strToLong("fil_w"),
+      strToLong("fil_h"), strToLong("dilation_h"), strToLong("dilation_w"),
+      strToLong("conv_stride_h"), strToLong("conv_stride_w"),
+      strToLong("padding_h"), strToLong("padding_w"), handle->module, builder,
+      kernelName);
+
+  PassManager pm(handle->module.getContext());
+  pm.addPass(mlir::miopen::createLowerMIOpenOpsStep1Pass());
+  pm.run(handle->module);
+
+  return handle;
+}
+
+extern "C" void DestroyMlirHandle(MlirHandle mlirHandle) {
+  MlirHandle_s *handle = static_cast<MlirHandle_s *>(mlirHandle);
+  delete handle;
+}
+
+extern "C" const char *MlirGenIgemmSource(MlirHandle mlirHandle) {
+  MlirHandle_s *handle = static_cast<MlirHandle_s *>(mlirHandle);
+  auto sourceCode = translateModuleToMIOpenCpp(handle->module);
+  return sourceCode->data();
+  ;
+}
+
+extern "C" const char *MlirGenIgemmHeader(MlirHandle mlirHandle) {
+  MlirHandle_s *handle = static_cast<MlirHandle_s *>(mlirHandle);
+  auto headerCode = translateModuleToMIOpenHeader(handle->module);
+  return headerCode->data();
+}
+
+extern "C" const char *MlirGenIgemmCflags(MlirHandle mlirHandle) {
+  MlirHandle_s *handle = static_cast<MlirHandle_s *>(mlirHandle);
+  auto cflagsTxt = translateModuleToMIOpenCFlags(handle->module);
+  return cflagsTxt->data();
+}
+} // namespace mlir
+
+// int main(){
+//  std::string mimic = R"( --operation conv2d_bwd_weight --fil_layout kcyx )"
+//  R"(--in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 )"
+//  R"(--out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 )"
+//  R"(--fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 )"
+//  R"(--conv_stride_w 1 --padding_h 0 --padding_w 0)";
+//  mlir::MlirHandle handle =
+//    mlir::CreateMlirHandle(mimic.c_str());
+//  std::string source = mlir::MlirGenIgemmSource(handle);
+//  std::string header = mlir::MlirGenIgemmHeader(handle);
+//  std::string cflags = mlir::MlirGenIgemmCflags(handle);
+//  mlir::DestroyMlirHandle(handle);
+//}

--- a/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.hpp
+++ b/mlir/tools/mlir-miopen-driver/mlir-miopen-lib.hpp
@@ -1,0 +1,15 @@
+namespace mlir {
+
+typedef void *MlirHandle;
+
+extern "C" MlirHandle CreateMlirHandle(const char *options);
+
+extern "C" const char *MlirGenIgemmSource(MlirHandle handle);
+
+extern "C" const char *MlirGenIgemmHeader(MlirHandle handle);
+
+extern "C" const char *MlirGenIgemmCflags(MlirHandle handle);
+
+extern "C" void DestroyMlirHandle(MlirHandle handle);
+
+} // namespace mlir


### PR DESCRIPTION
Implemented in 551a0e4:
* Fixed compilation issues exposed in LowerMIOpenOps
* Extracted common file composing logic into MlirParse.h
* Created libMLIRMIOpenThin for standalone static library
* Created libMLIRMIOpen for the target library with LLVM dependencies

Implemented in 5f9cc8e
* Choose the installation path of target libMLIRMIOpen.a
* Make libMLIRMIOpen.a a "fat", instead of "thin" library

Note: Please refer to file `mlir-miopen-lib.cpp`'s main function to refer to the API use case.