### PR TITLE
Updating MLIR generated filename and kernel name

### DIFF
--- a/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
+++ b/mlir/lib/Target/CppOutput/gridwise_convolution_implicit_gemm_v4r4.cpp
@@ -188,34 +188,26 @@ static constexpr StringLiteral kGemmNameABlockCopySrcDataPerRead[] = {
 void EmitCppPreamble(llvm::raw_ostream &output, miopen::ConvOpType opType) {
   output << kCppPreamblePart1;
 // Between Preamble Part 1 and Part 2:
-// #include "gridwise_convolution_implicit_gemm_v4r4_nchw_kcyx_nkhw.hpp"
   if (opType == miopen::ConvOpType::Conv2DOpType) {
-    output << R"(#include "gridwise_convolution_implicit_gemm_v4r4_)";
+    output << R"(#include "mlir_gen_igemm_conv2d_v4r4_fwd.hpp")";
   } else if (opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
-    output << R"(#include "gridwise_convolution_implicit_gemm_v1r1_)";
+    output << R"(#include "mlir_gen_igemm_conv2d_v1r1_bwd.hpp")";
   } else if (opType == miopen::ConvOpType::Conv2DBwdWeightOpType) {
-    output
-        << R"(#include "gridwise_convolution_backward_weight_implicit_gemm_v4r4_)";
+    output << R"(#include "mlir_gen_igemm_conv2d_v4r4_wrw.hpp")";
   }
-
-  // Change to fixed "mlir".
-  output << "mlir" << R"(.hpp")";
 
   output << kCppPreamblePart2;
 // Between Preamble Part 2 and Par 3:
-//    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_implicit_gemm_v4r4_nchw_kcyx_nkhw(
   if (opType == miopen::ConvOpType::Conv2DOpType) {
     output << R"(
-    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_implicit_gemm_v4r4_)";
+    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void mlir_gen_igemm_conv2d_v4r4_fwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
     output << R"(
-    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_backward_data_implicit_gemm_v1r1_)";
+    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void mlir_gen_igemm_conv2d_v1r1_bwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdWeightOpType) {
     output << R"(
-    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_backward_weight_implicit_gemm_v4r4_)";
+    __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void mlir_gen_igemm_conv2d_v4r4_wrw)";
   }
-  // Change to fixed "mlir".
-  output << "mlir";
 
   std::string argPInGlobal(kVarArgName[1]);
   std::string argPOutGlobal(kVarArgName[2]);
@@ -255,17 +247,14 @@ void EmitCppEpilogue(llvm::raw_ostream &output,
   //    GridwiseConvolutionImplicitGemm_v4r4_nchw_kcyx_nkhw
   if (opType == miopen::ConvOpType::Conv2DOpType) {
     output << R"(
-    constexpr auto gridwise_conv = GridwiseConvolutionImplicitGemm_v4r4_)";
+    constexpr auto gridwise_conv = MlirGenIgemmConv2dV4r4Fwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
     output << R"(
-    constexpr auto gridwise_conv = GridwiseConvolutionBackwardDataImplicitGemm_v1r1_)";
+    constexpr auto gridwise_conv = MlirGenIgemmConv2dV1r1Bwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdWeightOpType) {
     output << R"(
-    constexpr auto gridwise_conv = GridwiseConvolutionBackwardWeightImplicitGemm_v4r4_)";
+    constexpr auto gridwise_conv = MlirGenIgemmConv2dV4r4Wrw)";
   }
-
-  // Change to fixed "mlir".
-  output << "mlir";
 
   output << kCppEpiloguePart1;
   // Between Part1 and Part2:
@@ -443,19 +432,19 @@ void EmitHeaderPreamble(llvm::raw_ostream &output,
   std::string commentGemmK;
   std::string gemmNameABlockCopySrcDataPerRead;
   if (opType == miopen::ConvOpType::Conv2DOpType) {
-    headerIncludeGuard = "IMPLICIT_GEMM_V4R4";
+    headerIncludeGuard = "MLIR_GEN_IGEMM_CONV2D_V4R4_FWD";
     commentGemmM = "K";
     commentGemmN = "N * H * W";
     commentGemmK = "C * Y * X";
     gemmNameABlockCopySrcDataPerRead = kGemmNameABlockCopySrcDataPerRead[0].str();
   } else if (opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
-    headerIncludeGuard = "BACKWARD_DATA_IMPLICIT_GEMM_V1R1";
+    headerIncludeGuard = "MLIR_GEN_IGEMM_CONV2D_V1R1_BWD";
     commentGemmM = "C * Y * X";
     commentGemmN = "N * H * W";
     commentGemmK = "K";
     gemmNameABlockCopySrcDataPerRead = kGemmNameABlockCopySrcDataPerRead[1].str();
   } else if (opType == miopen::ConvOpType::Conv2DBwdWeightOpType) {
-    headerIncludeGuard = "BACKWARD_WEIGHT_IMPLICIT_GEMM_V4R4";
+    headerIncludeGuard = "MLIR_GEN_IGEMM_CONV2D_V4R4_WRW";
     commentGemmM = "K";
     commentGemmN = "C * Y * X";
     commentGemmK = "N * H * W";
@@ -467,15 +456,12 @@ void EmitHeaderPreamble(llvm::raw_ostream &output,
       commentGemmK.c_str(), gemmNameABlockCopySrcDataPerRead.c_str());
 
   if (opType == miopen::ConvOpType::Conv2DOpType) {
-    output << R"(struct GridwiseConvolutionImplicitGemm_v4r4_)";
+    output << R"(struct MlirGenIgemmConv2dV4r4Fwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdDataOpType) {
-    output << R"(struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_)";
+    output << R"(struct MlirGenIgemmConv2dV1r1Bwd)";
   } else if (opType == miopen::ConvOpType::Conv2DBwdWeightOpType) {
-    output << R"(struct GridwiseConvolutionBackwardWeightImplicitGemm_v4r4_)";
+    output << R"(struct MlirGenIgemmConv2dV4r4Wrw)";
   }
-
-  // Change to fixed "mlir".
-  output << "mlir";
 
   if (opType == miopen::ConvOpType::Conv2DOpType) {
     output << kHeaderPreamblePart2Forward;

--- a/mlir/test/Dialect/MIOpen/translate_bwd_data_kcyx_nchw_nkhw.mlir
+++ b/mlir/test/Dialect/MIOpen/translate_bwd_data_kcyx_nchw_nkhw.mlir
@@ -1,9 +1,9 @@
 // RUN: mlir-translate -mlir-to-miopen-cpp %s | FileCheck -check-prefix=MIOPEN-CPP %s
 // RUN: mlir-translate -mlir-to-miopen-hpp %s | FileCheck -check-prefix=MIOPEN-HPP %s
 
-// MIOPEN-CPP:  __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_backward_data_implicit_gemm_v1r1_mlir
+// MIOPEN-CPP:  __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void mlir_gen_igemm_conv2d_v1r1_bwd
 // MIOPEN-CPP:  FLOAT* const __restrict__ p_in_global
-// MIOPEN-HPP: struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_mlir
+// MIOPEN-HPP: struct MlirGenIgemmConv2dV1r1Bwd
 func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
   // filter tensor
   %filter_gemmK_gemmM = miopen.transform(%filter) {
@@ -159,7 +159,7 @@ func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?
 // MIOPEN-CPP:    constexpr auto weight_k_c_y_x_desc = make_native_tensor_descriptor(Sequence<k, c, y, x>{}, Sequence<stride_k, stride_c, stride_y, stride_x>{});
 // MIOPEN-CPP:     constexpr auto input_ni_ci_hi_wi_desc = make_native_tensor_descriptor(Sequence<ni, ci, hi, wi>{}, Sequence<stride_ni, stride_ci, stride_hi, stride_wi>{});
 // MIOPEN-CPP:     constexpr auto output_no_ko_ho_wo_desc = make_native_tensor_descriptor(Sequence<no, ko, ho, wo>{}, Sequence<stride_no, stride_ko, stride_ho, stride_wo>{});
-// MIOPEN-CPP:         constexpr auto gridwise_conv = GridwiseConvolutionBackwardDataImplicitGemm_v1r1_mlir
+// MIOPEN-CPP:         constexpr auto gridwise_conv = MlirGenIgemmConv2dV1r1Bwd
 // MIOPEN-CPP:        decltype(input_ni_ci_hi_wi_desc),
 // MIOPEN-CPP:        decltype(weight_k_c_y_x_desc),
 // MIOPEN-CPP:        decltype(output_no_ko_ho_wo_desc),

--- a/mlir/test/Dialect/MIOpen/translate_forward_kcyx_nchw_nkhw.mlir
+++ b/mlir/test/Dialect/MIOpen/translate_forward_kcyx_nchw_nkhw.mlir
@@ -1,9 +1,9 @@
 // RUN: mlir-translate -mlir-to-miopen-cpp %s | FileCheck -check-prefix=MIOPEN-CPP %s
 // RUN: mlir-translate -mlir-to-miopen-hpp %s | FileCheck -check-prefix=MIOPEN-HPP %s
 
-// MIOPEN-CPP:  __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void gridwise_convolution_implicit_gemm_v4r4_mlir
+// MIOPEN-CPP:  __launch_bounds__(CK_PARAM_TUNABLE_BLOCK_SIZE, 2) void mlir_gen_igemm_conv2d_v4r4_fwd
 // MIOPEN-CPP:  FLOAT* const __restrict__ p_out_global
-// MIOPEN-HPP: struct GridwiseConvolutionImplicitGemm_v4r4_mlir
+// MIOPEN-HPP: struct MlirGenIgemmConv2dV4r4Fwd
 func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?x?x?x?xf32>, %output : memref<?x?x?x?xf32>) {
   // filter tensor
   %filter_gemmK_gemmM = miopen.transform(%filter) {
@@ -159,7 +159,7 @@ func @miopen_transformed_conv2d(%filter : memref<?x?x?x?xf32>, %input : memref<?
 // MIOPEN-CPP:    constexpr auto weight_k_c_y_x_desc = make_native_tensor_descriptor(Sequence<k, c, y, x>{}, Sequence<stride_k, stride_c, stride_y, stride_x>{});
 // MIOPEN-CPP:     constexpr auto input_ni_ci_hi_wi_desc = make_native_tensor_descriptor(Sequence<ni, ci, hi, wi>{}, Sequence<stride_ni, stride_ci, stride_hi, stride_wi>{});
 // MIOPEN-CPP:     constexpr auto output_no_ko_ho_wo_desc = make_native_tensor_descriptor(Sequence<no, ko, ho, wo>{}, Sequence<stride_no, stride_ko, stride_ho, stride_wo>{});
-// MIOPEN-CPP:         constexpr auto gridwise_conv = GridwiseConvolutionImplicitGemm_v4r4_mlir
+// MIOPEN-CPP:         constexpr auto gridwise_conv = MlirGenIgemmConv2dV4r4Fwd
 // MIOPEN-CPP:        decltype(input_ni_ci_hi_wi_desc),
 // MIOPEN-CPP:        decltype(weight_k_c_y_x_desc),
 // MIOPEN-CPP:        decltype(output_no_ko_ho_wo_desc),

--- a/mlir/test/mlir-miopen-lib/populate_bwd.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bwd.mlir
@@ -3,5 +3,5 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_data --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
 
 // CFLAGS: miopen_conv2d_bwd_data_kcyx_nchw_nkhw
-// SOURCE: void gridwise_convolution_backward_data_implicit_gemm_v1r1_mlir
-// HEADER: struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_mlir 
+// SOURCE: void mlir_gen_igemm_conv2d_v1r1_bwd
+// HEADER: struct MlirGenIgemmConv2dV1r1Bwd 

--- a/mlir/test/mlir-miopen-lib/populate_bww.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_bww.mlir
@@ -3,5 +3,5 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d_bwd_weight --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
 
 // CFLAGS: miopen_conv2d_bwd_weight_kcyx_nchw_nkhw
-// SOURCE: void gridwise_convolution_backward_weight_implicit_gemm_v4r4_mlir
-// HEADER: struct GridwiseConvolutionBackwardWeightImplicitGemm_v4r4_mlir 
+// SOURCE: void mlir_gen_igemm_conv2d_v4r4_wrw
+// HEADER: struct MlirGenIgemmConv2dV4r4Wrw 

--- a/mlir/test/mlir-miopen-lib/populate_fw.mlir
+++ b/mlir/test/mlir-miopen-lib/populate_fw.mlir
@@ -3,5 +3,5 @@
 // RUN: mlir-miopen-lib-test --args " --operation conv2d --fil_layout kcyx --in_layout nchw --out_layout nkhw --batchsize 64 --in_channels 1024 --out_channels 1024 --in_h 14 --in_w 14 --out_h 14 --out_w 14 --fil_h 1 --fil_w 1 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0" --option header | FileCheck %s --check-prefix=HEADER
 
 // CFLAGS: miopen_conv2d_kcyx_nchw_nkhw
-// SOURCE: void gridwise_convolution_implicit_gemm_v4r4_mlir
-// HEADER: struct GridwiseConvolutionImplicitGemm_v4r4_mlir 
+// SOURCE: void mlir_gen_igemm_conv2d_v4r4_fwd
+// HEADER: struct MlirGenIgemmConv2dV4r4Fwd 


### PR DESCRIPTION
This is such that MIOpen is able to conveniently different the kernels according to their names.

Updated format: `mlir_gen_igemm_conv2d_<version>_<direction>`